### PR TITLE
Fedora 41 enabler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ log = "0.4"
 crossbeam-channel = "0.5"
 env_logger = "0.10"
 indicatif = "0.17"
-rusqlite = { version = "0.28.0", features = ["bundled"] }
-ureq = "=2.9.1"
+rusqlite = { version = "0.28.0" }
+ureq = "2.9.1"
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 bzip2 = "0.4.4"
-clap = { version = "=4.4.7", features = ["derive"] }
-clap_mangen = "=0.2.18"
+clap = { version = "4.4.7", features = ["derive"] }
+clap_mangen = "0.2.18"
 rand = "0.8.5"
 tar = "0.4.40"
 flate2 = "1.0.28"

--- a/src/db.rs
+++ b/src/db.rs
@@ -284,8 +284,9 @@ mod tests {
     }
 
     #[test]
-    fn check_version_reqs() {
+    fn online_check_version_reqs() {
         let rpmrelease = String::from("rawhide");
+        // Downloads current packages repository, needs network
         update_rpm_database(&rpmrelease).unwrap();
 
         let mut db = Connection::new(&rpmrelease).unwrap();


### PR DESCRIPTION
I have been able to compile this package on COPR for fedora. It seems no new dependency is required, just tuning of dependency versions, disabling bundled feature for rusqlite and skipping online during mock build.

I have working copr repository at: https://copr.fedorainfracloud.org/coprs/pemensik/rust/package/rust-cargo-rpmstatus/