### PR TITLE
Allow using bzip2 0.5 while keeping 0.4.4 compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ indicatif = "0.17"
 rusqlite = { version = "0.28.0" }
 ureq = "2.9.1"
 quick-xml = { version = "0.31.0", features = ["serialize"] }
-bzip2 = "0.4.4"
+bzip2 = ">=0.4.4, <0.6"
 clap = { version = "4.4.7", features = ["derive"] }
 clap_mangen = "0.2.18"
 rand = "0.8.5"


### PR DESCRIPTION
It compiles without any changes with 0.5.2, while it can work still with 0.4.4. Allow both.