### PR TITLE
Update to bzip2 0.6, still allowing 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,21 +105,11 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -669,6 +659,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ indicatif = "0.18"
 rusqlite = { version = "0.31.0" }
 ureq = "2.9.1"
 quick-xml = { version = "0.38.0", features = ["serialize"] }
-bzip2 = ">=0.4.4, <0.6"
+bzip2 = ">=0.4.4, <0.7"
 clap = { version = "4.4.7", features = ["derive"] }
 clap_mangen = "0.2.18"
 rand = "0.9"


### PR DESCRIPTION
This follows in the footsteps of 2103b88f11fdbcfd5dfabaa215ca3e50feca63b7, but also updates `Cargo.lock`.

The 0.6.0 release switches to `libbz2-rs-sys` as the default bzip2 backend. This rust implementation does not export C symbols by default. There are otherwise no API changes.

https://github.com/trifectatechfoundation/bzip2-rs/releases/tag/v0.6.0