### PR TITLE
Update quick-xml to 0.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ env_logger = "0.11"
 indicatif = "0.18"
 rusqlite = { version = "0.31.0" }
 ureq = "2.9.1"
-quick-xml = { version = "0.38.0", features = ["serialize"] }
+quick-xml = { version = "0.41.0", features = ["serialize"] }
 bzip2 = ">=0.4.4, <0.7"
 clap = { version = "4.4.7", features = ["derive"] }
 clap_mangen = "0.2.18"


### PR DESCRIPTION
Fixes RUSTSEC-2026-0194, RUSTSEC-2026-0195.

https://github.com/tafia/quick-xml/blob/v0.41.0/Changelog.md